### PR TITLE
Fix Wild Shape skills rendering "undefined" (skill-name case mismatch)

### DIFF
--- a/src/utils/calculations/__tests__/skills.test.ts
+++ b/src/utils/calculations/__tests__/skills.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { getSkillAbility, getSkillBonus, getAllSkillBonuses } from '../skills';
+import {
+  getSkillAbility,
+  getSkillBonus,
+  getAllSkillBonuses,
+  normalizeSkillName,
+} from '../skills';
 import type { AbilityName, SkillProficiency } from '../../../models';
 
 describe('getSkillAbility', () => {
@@ -250,5 +255,27 @@ describe('getAllSkillBonuses', () => {
       expect(result).toHaveProperty(skill);
       expect(typeof result[skill]).toBe('number');
     }
+  });
+});
+
+describe('normalizeSkillName', () => {
+  it('normalizes lowercase beast skill names to canonical title-case', () => {
+    expect(normalizeSkillName('stealth')).toBe('Stealth');
+    expect(normalizeSkillName('perception')).toBe('Perception');
+  });
+
+  it('normalizes multi-word skill names', () => {
+    expect(normalizeSkillName('sleight of hand')).toBe('Sleight of Hand');
+    expect(normalizeSkillName('animal handling')).toBe('Animal Handling');
+  });
+
+  it('leaves already-canonical names unchanged', () => {
+    expect(normalizeSkillName('Stealth')).toBe('Stealth');
+  });
+
+  it('falls back to the input for unrecognized skills', () => {
+    expect(normalizeSkillName('Underwater Basket Weaving')).toBe(
+      'Underwater Basket Weaving'
+    );
   });
 });

--- a/src/utils/calculations/__tests__/wildShape.test.ts
+++ b/src/utils/calculations/__tests__/wildShape.test.ts
@@ -1113,6 +1113,69 @@ describe('calculateWildshapedDruid', () => {
       expect(wildshaped.skillBonuses['Stealth']).toBe(8);
     });
 
+    it('should honor lowercase beast skill data (regression: skill-name case mismatch)', () => {
+      // Mirrors real beast JSON, which stores skills lowercase.
+      const druid = createMockDruid({
+        druidLevel: 5,
+        totalCharacterLevel: 5,
+        wisdom: 10, // +0, not proficient in Perception
+        skillProficiencies: [],
+      });
+      const beast = createFullMockBeast({
+        challengeRating: 0.25, // PB +2
+        dexterity: 18, // +4
+        wisdom: 12, // +1
+        skillProficiencies: [
+          { skill: 'stealth', proficiencyLevel: 'expertise' }, // +4 + 2*2 = +8
+          { skill: 'perception', proficiencyLevel: 'proficient' }, // +1 + 2 = +3
+        ],
+      });
+
+      const wildshaped = calculateWildshapedDruid(druid, beast);
+
+      // Beast proficiency/expertise is applied, keyed by canonical title-case.
+      expect(wildshaped.skillBonuses['Stealth']).toBe(8);
+      expect(wildshaped.skillBonuses['Perception']).toBe(3);
+
+      // Merged proficiencies use canonical names so the UI lookup resolves.
+      const stealthEntry = wildshaped.skillProficiencies.find(
+        (p) => p.skill === 'Stealth'
+      );
+      expect(stealthEntry).toBeDefined();
+      expect(stealthEntry?.proficiencyLevel).toBe('expertise');
+      expect(wildshaped.skillBonuses[stealthEntry!.skill]).toBe(8);
+      // No lowercase entry should leak through.
+      expect(
+        wildshaped.skillProficiencies.some((p) => p.skill === 'stealth')
+      ).toBe(false);
+    });
+
+    it('should not duplicate a skill when druid and beast cased differently', () => {
+      const druid = createMockDruid({
+        druidLevel: 5,
+        totalCharacterLevel: 5,
+        skillProficiencies: [
+          { skill: 'Stealth', proficiencyLevel: 'proficient' },
+        ],
+      });
+      const beast = createFullMockBeast({
+        challengeRating: 0.25,
+        dexterity: 18,
+        skillProficiencies: [
+          { skill: 'stealth', proficiencyLevel: 'expertise' },
+        ],
+      });
+
+      const wildshaped = calculateWildshapedDruid(druid, beast);
+
+      const stealthEntries = wildshaped.skillProficiencies.filter(
+        (p) => p.skill.toLowerCase() === 'stealth'
+      );
+      expect(stealthEntries).toHaveLength(1);
+      expect(stealthEntries[0].skill).toBe('Stealth');
+      expect(stealthEntries[0].proficiencyLevel).toBe('expertise');
+    });
+
     it('should calculate all 18 skills', () => {
       const druid = createMockDruid({ druidLevel: 5 });
       const beast = createFullMockBeast({ challengeRating: 0.25 });

--- a/src/utils/calculations/skills.ts
+++ b/src/utils/calculations/skills.ts
@@ -52,6 +52,32 @@ const SKILL_ABILITY_MAP_LOWER: Record<string, AbilityName> = Object.fromEntries(
   Object.entries(SKILL_ABILITY_MAP).map(([k, v]) => [k.toLowerCase(), v])
 );
 
+/**
+ * Lookup from lowercased skill name to its canonical title-cased form.
+ */
+const CANONICAL_SKILL_BY_LOWER: Record<string, string> = Object.fromEntries(
+  Object.keys(SKILL_ABILITY_MAP).map((name) => [name.toLowerCase(), name])
+);
+
+/**
+ * Normalizes a skill name to its canonical title-cased form.
+ *
+ * Beast data stores skills lowercase (e.g. "stealth") while the calc layer and
+ * druid store use title-cased canonical names (e.g. "Stealth"). Normalizing at
+ * the boundary keeps both sides keyed consistently. Falls back to the input if
+ * the skill is unrecognized.
+ *
+ * @param skillName - The skill name in any casing
+ * @returns The canonical title-cased skill name
+ *
+ * @example
+ * normalizeSkillName('stealth')          // returns 'Stealth'
+ * normalizeSkillName('sleight of hand')  // returns 'Sleight of Hand'
+ */
+export function normalizeSkillName(skillName: string): string {
+  return CANONICAL_SKILL_BY_LOWER[skillName.toLowerCase()] ?? skillName;
+}
+
 export function getSkillAbility(skillName: string): AbilityName {
   const ability =
     SKILL_ABILITY_MAP[skillName] ??

--- a/src/utils/calculations/wildShape.ts
+++ b/src/utils/calculations/wildShape.ts
@@ -26,7 +26,7 @@ import {
   getProficiencyBonusFromLevel,
   getProficiencyBonusFromCR,
 } from './proficiencyBonus';
-import { getSkillBonus } from './skills';
+import { getSkillBonus, normalizeSkillName } from './skills';
 import { getSavingThrowBonus } from './savingThrows';
 import { getAbilityModifier } from './abilityScores';
 
@@ -373,12 +373,12 @@ function mergeSkillBonuses(
   // Create maps for faster lookup
   const druidProfMap = new Map<string, ProficiencyLevel>();
   for (const prof of druidSkillProfs) {
-    druidProfMap.set(prof.skill, prof.proficiencyLevel);
+    druidProfMap.set(normalizeSkillName(prof.skill), prof.proficiencyLevel);
   }
 
   const beastProfMap = new Map<string, ProficiencyLevel>();
   for (const prof of beastSkillProfs) {
-    beastProfMap.set(prof.skill, prof.proficiencyLevel);
+    beastProfMap.set(normalizeSkillName(prof.skill), prof.proficiencyLevel);
   }
 
   // Calculate for each skill
@@ -505,21 +505,23 @@ function mergeSkillProficiencies(
 ): SkillProficiency[] {
   const profMap = new Map<string, SkillProficiency>();
 
-  // Add druid proficiencies
+  // Add druid proficiencies (keyed and stored with canonical skill names)
   for (const prof of druidSkillProfs) {
-    profMap.set(prof.skill, prof);
+    const skill = normalizeSkillName(prof.skill);
+    profMap.set(skill, { ...prof, skill });
   }
 
   // Add or override with beast proficiencies if beast has higher bonus
   for (const beastProf of beastSkillProfs) {
+    const skill = normalizeSkillName(beastProf.skill);
     const druidBonus = getSkillBonus(
-      beastProf.skill,
+      skill,
       hybridAbilities,
       druidPB,
-      profMap.get(beastProf.skill)?.proficiencyLevel || null
+      profMap.get(skill)?.proficiencyLevel || null
     );
     const beastBonus = getSkillBonus(
-      beastProf.skill,
+      skill,
       beastAbilities,
       beastPB,
       beastProf.proficiencyLevel
@@ -527,7 +529,7 @@ function mergeSkillProficiencies(
 
     // If beast has higher bonus, use beast's proficiency level
     if (beastBonus >= druidBonus) {
-      profMap.set(beastProf.skill, beastProf);
+      profMap.set(skill, { ...beastProf, skill });
     }
   }
 


### PR DESCRIPTION
Wild Shape skill bonuses rendered as "undefined" because beast JSON stores skill names lowercase (e.g. `stealth`) while the calc layer and druid store use title-cased canonical names (e.g. `Stealth`), so beast proficiency/expertise was dropped and the UI lookup missed. This adds a `normalizeSkillName` helper and applies it in `mergeSkillBonuses` and `mergeSkillProficiencies` to normalize names at the calc-layer boundary — no UI or data-file changes needed. Regression tests now use realistic lowercase beast data (which the old tests masked by using title-case mocks).

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)