### PR TITLE
Add multi-druid support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,13 +4,37 @@ import { StatusBar } from 'expo-status-bar';
 import React, { useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 
+import { ConfirmDialog } from './src/components/ConfirmDialog';
+import { CreateDruidDialog } from './src/components/CreateDruidDialog';
+import { DruidSwitcher } from './src/components/DruidSwitcher';
 import { CharacterSetupScreen } from './src/screens/CharacterSetupScreen';
 import { WildShapeScreen } from './src/screens/WildShapeScreen';
+import { useDruidStore } from './src/store/useDruidStore';
 
 type Tab = 'character' | 'wildshape';
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<Tab>('character');
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  const activeDruidId = useDruidStore((s) => s.activeDruidId);
+  const activeDruidName = useDruidStore((s) => s.name);
+  const druidCount = useDruidStore((s) => s.druidOrder.length);
+  const createDruid = useDruidStore((s) => s.createDruid);
+  const deleteDruid = useDruidStore((s) => s.deleteDruid);
+  const isOnlyDruid = druidCount <= 1;
+
+  const handleCreate = (name: string) => {
+    createDruid(name);
+    setCreateDialogOpen(false);
+    setActiveTab('character');
+  };
+
+  const handleConfirmDelete = () => {
+    deleteDruid(activeDruidId);
+    setDeleteDialogOpen(false);
+  };
 
   return (
     <>
@@ -21,6 +45,28 @@ export default function App() {
           <Text className="text-3xl font-bold text-green-800 text-center py-4">
             Wildshape.me
           </Text>
+          {/* Druid switcher */}
+          <View className="flex-row items-center gap-2 pb-3">
+            <DruidSwitcher />
+            <Pressable
+              onPress={() => setCreateDialogOpen(true)}
+              className="px-3 py-2 rounded-md border-2 border-green-700 bg-transparent"
+            >
+              <Text className="font-semibold text-sm text-green-700">
+                + New Druid
+              </Text>
+            </Pressable>
+            {!isOnlyDruid && (
+              <Pressable
+                onPress={() => setDeleteDialogOpen(true)}
+                className="px-3 py-2 rounded-md border-2 border-red-600 bg-transparent"
+              >
+                <Text className="font-semibold text-sm text-red-600">
+                  Delete {activeDruidName}
+                </Text>
+              </Pressable>
+            )}
+          </View>
           {/* Tab bar */}
           <View className="flex-row border-b-2 border-gray-200">
             <Pressable
@@ -51,6 +97,19 @@ export default function App() {
           <WildShapeScreen />
         )}
       </View>
+      <CreateDruidDialog
+        visible={createDialogOpen}
+        onCreate={handleCreate}
+        onCancel={() => setCreateDialogOpen(false)}
+      />
+      <ConfirmDialog
+        visible={deleteDialogOpen}
+        title={`Delete ${activeDruidName}?`}
+        message="This will permanently delete this druid's data. This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteDialogOpen(false)}
+      />
     </>
   );
 }

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Modal, Pressable, Text, View } from 'react-native';
+
+interface Props {
+  visible: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  visible,
+  title,
+  message,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View className="flex-1 justify-center items-center bg-black/50 px-6">
+        <View className="w-full max-w-sm bg-white rounded-xl p-4 shadow-sm">
+          <Text className="text-lg font-semibold mb-2 text-gray-800">
+            {title}
+          </Text>
+          <Text className="text-base text-gray-600 mb-4">{message}</Text>
+          <View className="flex-row justify-end gap-3">
+            <Pressable
+              onPress={onCancel}
+              className="px-5 py-2 rounded-md border-2 bg-transparent border-green-700"
+            >
+              <Text className="font-semibold text-base text-green-700">
+                Cancel
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={onConfirm}
+              className="px-5 py-2 rounded-md border-2 bg-red-600 border-red-600"
+            >
+              <Text className="font-semibold text-base text-white">
+                {confirmLabel}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/CreateDruidDialog.tsx
+++ b/src/components/CreateDruidDialog.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Modal, Pressable, Text, TextInput, View } from 'react-native';
+
+interface Props {
+  visible: boolean;
+  onCreate: (name: string) => void;
+  onCancel: () => void;
+}
+
+export function CreateDruidDialog({ visible, onCreate, onCancel }: Props) {
+  const [name, setName] = useState('');
+
+  const trimmedName = name.trim();
+
+  const handleCancel = () => {
+    setName('');
+    onCancel();
+  };
+
+  const handleCreate = () => {
+    if (!trimmedName) {
+      return;
+    }
+    onCreate(trimmedName);
+    setName('');
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={handleCancel}
+    >
+      <View className="flex-1 justify-center items-center bg-black/50 px-6">
+        <View className="w-full max-w-sm bg-white rounded-xl p-4 shadow-sm">
+          <Text className="text-lg font-semibold mb-2 text-gray-800">
+            Create New Druid
+          </Text>
+          <TextInput
+            value={name}
+            onChangeText={setName}
+            placeholder="Druid name"
+            autoFocus
+            className="border-2 border-gray-300 rounded-md px-3 py-2 text-base text-gray-800 bg-white mb-4"
+          />
+          <View className="flex-row justify-end gap-3">
+            <Pressable
+              onPress={handleCancel}
+              className="px-5 py-2 rounded-md border-2 bg-transparent border-green-700"
+            >
+              <Text className="font-semibold text-base text-green-700">
+                Cancel
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={handleCreate}
+              disabled={!trimmedName}
+              className={`px-5 py-2 rounded-md border-2 ${
+                trimmedName
+                  ? 'bg-green-700 border-green-700'
+                  : 'border-gray-300 bg-gray-100'
+              }`}
+            >
+              <Text
+                className={`font-semibold text-base ${
+                  trimmedName ? 'text-white' : 'text-gray-400'
+                }`}
+              >
+                Create
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/DruidSwitcher.tsx
+++ b/src/components/DruidSwitcher.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+
+import { useDruidStore } from '../store/useDruidStore';
+
+export function DruidSwitcher() {
+  const [open, setOpen] = useState(false);
+  const druids = useDruidStore((s) => s.druids);
+  const druidOrder = useDruidStore((s) => s.druidOrder);
+  const activeDruidId = useDruidStore((s) => s.activeDruidId);
+  const setActiveDruid = useDruidStore((s) => s.setActiveDruid);
+
+  const activeName = druids[activeDruidId]?.name ?? '';
+
+  const handleSelect = (id: string) => {
+    setActiveDruid(id);
+    setOpen(false);
+  };
+
+  return (
+    <View className="flex-1">
+      <Pressable
+        onPress={() => setOpen(true)}
+        className="border-2 border-green-700 rounded-md px-3 py-2 flex-row justify-between items-center"
+      >
+        <Text className="text-base text-gray-800" numberOfLines={1}>
+          {activeName}
+        </Text>
+        <Text className="text-gray-400">▼</Text>
+      </Pressable>
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable
+          className="flex-1 justify-end bg-black/50"
+          onPress={() => setOpen(false)}
+        >
+          <View className="mx-4 mb-8 bg-white rounded-xl overflow-hidden max-h-96">
+            <ScrollView>
+              {druidOrder.map((id) => (
+                <Pressable
+                  key={id}
+                  onPress={() => handleSelect(id)}
+                  className="px-4 py-3 border-b border-gray-100"
+                >
+                  <Text
+                    className={`text-base ${id === activeDruidId ? 'text-green-700 font-semibold' : 'text-gray-800'}`}
+                  >
+                    {druids[id].name}
+                  </Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </View>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}

--- a/src/components/DruidSwitcher.web.tsx
+++ b/src/components/DruidSwitcher.web.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { View } from 'react-native';
+
+import { useDruidStore } from '../store/useDruidStore';
+
+export function DruidSwitcher() {
+  const druids = useDruidStore((s) => s.druids);
+  const druidOrder = useDruidStore((s) => s.druidOrder);
+  const activeDruidId = useDruidStore((s) => s.activeDruidId);
+  const setActiveDruid = useDruidStore((s) => s.setActiveDruid);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setActiveDruid(e.target.value);
+  };
+
+  return (
+    <View className="flex-1">
+      <select
+        value={activeDruidId}
+        onChange={handleChange}
+        className="border-2 border-green-700 rounded-md px-3 py-2 text-base text-gray-800 bg-white focus:outline-none w-full"
+      >
+        {druidOrder.map((id) => (
+          <option key={id} value={id}>
+            {druids[id].name}
+          </option>
+        ))}
+      </select>
+    </View>
+  );
+}

--- a/src/components/NameInput.tsx
+++ b/src/components/NameInput.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TextInput } from 'react-native';
+
+import { useDruidStore } from '../store/useDruidStore';
+
+export function NameInput() {
+  const name = useDruidStore((s) => s.name);
+  const setDruidName = useDruidStore((s) => s.setDruidName);
+
+  const handleBlur = () => {
+    if (!name.trim()) {
+      setDruidName('My Druid');
+    }
+  };
+
+  return (
+    <TextInput
+      value={name}
+      onChangeText={setDruidName}
+      onBlur={handleBlur}
+      placeholder="Druid name"
+      className="border-2 border-gray-300 rounded-md px-3 py-2 text-base text-gray-800 bg-white"
+    />
+  );
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -302,6 +302,7 @@ export const DRUID_CIRCLES: Record<Edition, DruidCircle[]> = {
  * Druid character
  */
 export interface Druid extends Creature {
+  id: string;
   totalCharacterLevel: number;
   druidLevel: number;
   druidCircle: DruidCircle;

--- a/src/screens/CharacterSetupScreen.tsx
+++ b/src/screens/CharacterSetupScreen.tsx
@@ -9,6 +9,7 @@ import { SkillsSection } from '../components/SkillsSection';
 import { DruidCircleSelect } from '../components/DruidCircleSelect';
 import { EditionSelector } from '../components/EditionSelector';
 import { LevelInput } from '../components/LevelInput';
+import { NameInput } from '../components/NameInput';
 import { AbilityName } from '../models';
 
 const ABILITY_NAMES: AbilityName[] = [
@@ -26,6 +27,13 @@ export function CharacterSetupScreen() {
       className="flex-1 bg-gray-50"
       contentContainerClassName="px-4 py-6"
     >
+      <View className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <Text className="text-lg font-semibold mb-2 text-gray-800">
+          Druid Name
+        </Text>
+        <NameInput />
+      </View>
+
       <View className="bg-white rounded-xl p-4 mb-4 shadow-sm">
         <Text className="text-lg font-semibold mb-2 text-gray-800">
           Edition

--- a/src/screens/WildShapeScreen.tsx
+++ b/src/screens/WildShapeScreen.tsx
@@ -94,6 +94,8 @@ function formatCR(cr: number): string {
 }
 
 export function WildShapeScreen() {
+  const druidId = useDruidStore((s) => s.id);
+  const druidName = useDruidStore((s) => s.name);
   const edition = useDruidStore((s) => s.edition);
   const druidLevel = useDruidStore((s) => s.druidLevel);
   const druidCircle = useDruidStore((s) => s.druidCircle);
@@ -137,7 +139,8 @@ export function WildShapeScreen() {
     );
 
     const druidObj: Druid = {
-      name: 'Druid',
+      id: druidId,
+      name: druidName,
       edition,
       size: 'Medium',
       strength,

--- a/src/store/__tests__/migrateDruidStore.test.ts
+++ b/src/store/__tests__/migrateDruidStore.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from '@jest/globals';
+import { migrateDruidStorage, recordFromDefaults } from '../migrateDruidStore';
+
+describe('migrateDruidStorage', () => {
+  it('wraps a legacy (version 0) flat druid state into a single-druid multi-druid shape', () => {
+    const legacy = {
+      edition: '2014',
+      druidLevel: 5,
+      druidCircle: 'Circle of the Moon',
+      strength: 14,
+      dexterity: 12,
+      constitution: 13,
+      intelligence: 8,
+      wisdom: 16,
+      charisma: 10,
+      savingThrowProficiencies: ['intelligence', 'wisdom'],
+      savingThrowOverrides: {},
+      skillProficiencies: [{ skill: 'Nature', proficiencyLevel: 'proficient' }],
+      skillOverrides: {},
+      traitChoices: { someGroup: 'Choice A' },
+    };
+
+    const migrated = migrateDruidStorage(legacy, 0);
+
+    expect(migrated.name).toBe('My Druid');
+    expect(migrated.edition).toBe('2014');
+    expect(migrated.druidLevel).toBe(5);
+    expect(migrated.druidCircle).toBe('Circle of the Moon');
+    expect(migrated.strength).toBe(14);
+    expect(migrated.wisdom).toBe(16);
+    expect(migrated.skillProficiencies).toEqual([
+      { skill: 'Nature', proficiencyLevel: 'proficient' },
+    ]);
+    expect(migrated.traitChoices).toEqual({ someGroup: 'Choice A' });
+
+    expect(migrated.druidOrder).toEqual([migrated.id]);
+    expect(migrated.activeDruidId).toBe(migrated.id);
+    expect(Object.keys(migrated.druids)).toEqual([migrated.id]);
+    expect(migrated.druids[migrated.id]).toMatchObject({
+      name: 'My Druid',
+      edition: '2014',
+      druidLevel: 5,
+    });
+  });
+
+  it('falls back to store defaults when persisted state is missing or empty', () => {
+    const migrated = migrateDruidStorage(undefined, 0);
+
+    expect(migrated.name).toBe('My Druid');
+    expect(migrated.edition).toBe('2024');
+    expect(migrated.druidLevel).toBe(2);
+    expect(migrated.druidCircle).toBeNull();
+    expect(migrated.strength).toBe(10);
+  });
+
+  it('passes through unchanged when already at version 1', () => {
+    const record = recordFromDefaults('Already Migrated');
+    const alreadyMigrated = {
+      ...record,
+      druids: { [record.id]: record },
+      druidOrder: [record.id],
+      activeDruidId: record.id,
+    };
+
+    expect(migrateDruidStorage(alreadyMigrated, 1)).toBe(alreadyMigrated);
+  });
+});
+
+describe('recordFromDefaults', () => {
+  it('produces a druid record with default stats and a unique id', () => {
+    const a = recordFromDefaults('Alice');
+    const b = recordFromDefaults('Bob');
+
+    expect(a.name).toBe('Alice');
+    expect(a.edition).toBe('2024');
+    expect(a.druidLevel).toBe(2);
+    expect(a.druidCircle).toBeNull();
+    expect(a.strength).toBe(10);
+    expect(a.savingThrowProficiencies).toEqual(['intelligence', 'wisdom']);
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/src/store/__tests__/useDruidStore.test.ts
+++ b/src/store/__tests__/useDruidStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
+import { useDruidStore } from '../useDruidStore';
+import { recordFromDefaults } from '../migrateDruidStore';
+
+describe('useDruidStore', () => {
+  beforeEach(() => {
+    const record = recordFromDefaults('My Druid');
+    useDruidStore.setState({
+      ...record,
+      druids: { [record.id]: record },
+      druidOrder: [record.id],
+      activeDruidId: record.id,
+    });
+  });
+
+  it('starts with a single default druid named "My Druid"', () => {
+    const state = useDruidStore.getState();
+    expect(state.druidOrder).toHaveLength(1);
+    expect(state.name).toBe('My Druid');
+    expect(state.druids[state.activeDruidId].name).toBe('My Druid');
+  });
+
+  it('createDruid adds a new druid with default stats and switches to it', () => {
+    const initialId = useDruidStore.getState().activeDruidId;
+    const newId = useDruidStore.getState().createDruid('Thornwood');
+
+    const state = useDruidStore.getState();
+    expect(state.druidOrder).toEqual([initialId, newId]);
+    expect(state.activeDruidId).toBe(newId);
+    expect(state.name).toBe('Thornwood');
+    expect(state.druidLevel).toBe(2);
+    expect(state.edition).toBe('2024');
+  });
+
+  it('editing the active druid does not affect other druids', () => {
+    const firstId = useDruidStore.getState().activeDruidId;
+    useDruidStore.getState().setAbilityScore('strength', 18);
+
+    const secondId = useDruidStore.getState().createDruid('Second Druid');
+    useDruidStore.getState().setAbilityScore('strength', 6);
+
+    expect(useDruidStore.getState().druids[firstId].strength).toBe(18);
+    expect(useDruidStore.getState().druids[secondId].strength).toBe(6);
+
+    useDruidStore.getState().setActiveDruid(firstId);
+    expect(useDruidStore.getState().strength).toBe(18);
+  });
+
+  it('deleteDruid removes a druid and activates another when the active one is deleted', () => {
+    const firstId = useDruidStore.getState().activeDruidId;
+    const secondId = useDruidStore.getState().createDruid('Second Druid');
+
+    useDruidStore.getState().deleteDruid(secondId);
+
+    const state = useDruidStore.getState();
+    expect(state.druidOrder).toEqual([firstId]);
+    expect(state.activeDruidId).toBe(firstId);
+    expect(state.druids[secondId]).toBeUndefined();
+  });
+
+  it('deleteDruid is a no-op when only one druid remains', () => {
+    const onlyId = useDruidStore.getState().activeDruidId;
+
+    useDruidStore.getState().deleteDruid(onlyId);
+
+    const state = useDruidStore.getState();
+    expect(state.druidOrder).toEqual([onlyId]);
+    expect(state.druids[onlyId]).toBeDefined();
+  });
+
+  it('setDruidName renames only the active druid', () => {
+    useDruidStore.getState().setDruidName('Renamed Druid');
+    const state = useDruidStore.getState();
+    expect(state.name).toBe('Renamed Druid');
+    expect(state.druids[state.activeDruidId].name).toBe('Renamed Druid');
+  });
+});

--- a/src/store/migrateDruidStore.ts
+++ b/src/store/migrateDruidStore.ts
@@ -1,0 +1,73 @@
+import { AbilityName, DruidCircle, Edition, SkillProficiency } from '../models';
+import { generateId } from '../utils/id';
+
+export interface DruidRecord {
+  id: string;
+  name: string;
+  edition: Edition;
+  druidLevel: number;
+  druidCircle: DruidCircle;
+  strength: number;
+  dexterity: number;
+  constitution: number;
+  intelligence: number;
+  wisdom: number;
+  charisma: number;
+  savingThrowProficiencies: AbilityName[];
+  savingThrowOverrides: Partial<Record<AbilityName, number>>;
+  skillProficiencies: SkillProficiency[];
+  skillOverrides: Partial<Record<string, number>>;
+  traitChoices: Record<string, string>;
+}
+
+export interface MultiDruidData extends DruidRecord {
+  druids: Record<string, DruidRecord>;
+  druidOrder: string[];
+  activeDruidId: string;
+}
+
+export function recordFromDefaults(name: string): DruidRecord {
+  return {
+    id: generateId(),
+    name,
+    edition: '2024',
+    druidLevel: 2,
+    druidCircle: null,
+    strength: 10,
+    dexterity: 10,
+    constitution: 10,
+    intelligence: 10,
+    wisdom: 10,
+    charisma: 10,
+    savingThrowProficiencies: ['intelligence', 'wisdom'],
+    savingThrowOverrides: {},
+    skillProficiencies: [],
+    skillOverrides: {},
+    traitChoices: {},
+  };
+}
+
+type LegacyDruidState = Partial<Omit<DruidRecord, 'id' | 'name'>>;
+
+export function migrateDruidStorage(
+  persistedState: unknown,
+  version: number
+): MultiDruidData {
+  if (version >= 1) {
+    return persistedState as MultiDruidData;
+  }
+
+  const legacy = (persistedState ?? {}) as LegacyDruidState;
+  const defaults = recordFromDefaults('My Druid');
+  const record: DruidRecord = {
+    ...defaults,
+    ...legacy,
+  };
+
+  return {
+    ...record,
+    druids: { [record.id]: record },
+    druidOrder: [record.id],
+    activeDruidId: record.id,
+  };
+}

--- a/src/store/useDruidStore.ts
+++ b/src/store/useDruidStore.ts
@@ -2,29 +2,18 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { AbilityName, DruidCircle, Edition, ProficiencyLevel } from '../models';
 import {
-  AbilityName,
-  DruidCircle,
-  Edition,
-  ProficiencyLevel,
-  SkillProficiency,
-} from '../models';
+  DruidRecord,
+  migrateDruidStorage,
+  recordFromDefaults,
+} from './migrateDruidStore';
 
-interface DruidState {
-  edition: Edition;
-  druidLevel: number;
-  druidCircle: DruidCircle;
-  strength: number;
-  dexterity: number;
-  constitution: number;
-  intelligence: number;
-  wisdom: number;
-  charisma: number;
-  savingThrowProficiencies: AbilityName[];
-  savingThrowOverrides: Partial<Record<AbilityName, number>>;
-  skillProficiencies: SkillProficiency[];
-  skillOverrides: Partial<Record<string, number>>;
-  traitChoices: Record<string, string>;
+interface DruidStoreState extends DruidRecord {
+  druids: Record<string, DruidRecord>;
+  druidOrder: string[];
+  activeDruidId: string;
+
   setEdition: (edition: Edition) => void;
   setDruidLevel: (level: number) => void;
   setDruidCircle: (circle: DruidCircle) => void;
@@ -34,93 +23,153 @@ interface DruidState {
   setSavingThrowOverride: (ability: AbilityName, value: number | null) => void;
   setSkillProficiency: (skill: string, level: ProficiencyLevel | null) => void;
   setSkillOverride: (skill: string, value: number | null) => void;
+  setDruidName: (name: string) => void;
+  createDruid: (name: string) => string;
+  deleteDruid: (id: string) => void;
+  setActiveDruid: (id: string) => void;
 }
 
-export const useDruidStore = create<DruidState>()(
+export const useDruidStore = create<DruidStoreState>()(
   persist(
-    (set) => ({
-      edition: '2024',
-      druidLevel: 2,
-      druidCircle: null,
-      strength: 10,
-      dexterity: 10,
-      constitution: 10,
-      intelligence: 10,
-      wisdom: 10,
-      charisma: 10,
-      savingThrowProficiencies: ['intelligence', 'wisdom'],
-      savingThrowOverrides: {},
-      skillProficiencies: [],
-      skillOverrides: {},
-      traitChoices: {},
-      setEdition: (edition) => set({ edition, druidCircle: null }),
-      setDruidLevel: (level) =>
-        set({ druidLevel: Math.min(20, Math.max(2, level)) }),
-      setDruidCircle: (circle) => set({ druidCircle: circle }),
-      setAbilityScore: (ability, score) =>
-        set({ [ability]: Math.min(30, Math.max(1, score)) }),
-      toggleSavingThrowProficiency: (ability) =>
+    (set, get) => {
+      const applyToActive = (
+        patch:
+          | Partial<DruidRecord>
+          | ((record: DruidRecord) => Partial<DruidRecord>)
+      ) =>
         set((state) => {
-          const current = state.savingThrowProficiencies;
-          const next = current.includes(ability)
-            ? current.filter((a) => a !== ability)
-            : [...current, ability];
-          return { savingThrowProficiencies: next };
-        }),
-      setSavingThrowOverride: (ability, value) =>
-        set((state) => {
-          const overrides = { ...state.savingThrowOverrides };
-          if (value === null) {
-            delete overrides[ability];
-          } else {
-            overrides[ability] = value;
-          }
-          return { savingThrowOverrides: overrides };
-        }),
-      setSkillProficiency: (skill, level) =>
-        set((state) => {
-          if (level === null) {
-            return {
-              skillProficiencies: state.skillProficiencies.filter(
-                (p) => p.skill !== skill
-              ),
-            };
-          }
-          const existing = state.skillProficiencies.find(
-            (p) => p.skill === skill
-          );
-          if (existing) {
-            return {
-              skillProficiencies: state.skillProficiencies.map((p) =>
-                p.skill === skill ? { ...p, proficiencyLevel: level } : p
-              ),
-            };
-          }
+          const id = state.activeDruidId;
+          const record = state.druids[id];
+          const resolved = typeof patch === 'function' ? patch(record) : patch;
           return {
-            skillProficiencies: [
-              ...state.skillProficiencies,
-              { skill, proficiencyLevel: level },
-            ],
+            ...resolved,
+            druids: { ...state.druids, [id]: { ...record, ...resolved } },
           };
-        }),
-      setSkillOverride: (skill, value) =>
-        set((state) => {
-          const overrides = { ...state.skillOverrides };
-          if (value === null) {
-            delete overrides[skill];
-          } else {
-            overrides[skill] = value;
+        });
+
+      const initial = recordFromDefaults('My Druid');
+
+      return {
+        ...initial,
+        druids: { [initial.id]: initial },
+        druidOrder: [initial.id],
+        activeDruidId: initial.id,
+
+        setEdition: (edition) => applyToActive({ edition, druidCircle: null }),
+        setDruidLevel: (level) =>
+          applyToActive({ druidLevel: Math.min(20, Math.max(2, level)) }),
+        setDruidCircle: (circle) => applyToActive({ druidCircle: circle }),
+        setAbilityScore: (ability, score) =>
+          applyToActive({ [ability]: Math.min(30, Math.max(1, score)) }),
+        toggleSavingThrowProficiency: (ability) =>
+          applyToActive((record) => {
+            const current = record.savingThrowProficiencies;
+            const next = current.includes(ability)
+              ? current.filter((a) => a !== ability)
+              : [...current, ability];
+            return { savingThrowProficiencies: next };
+          }),
+        setSavingThrowOverride: (ability, value) =>
+          applyToActive((record) => {
+            const overrides = { ...record.savingThrowOverrides };
+            if (value === null) {
+              delete overrides[ability];
+            } else {
+              overrides[ability] = value;
+            }
+            return { savingThrowOverrides: overrides };
+          }),
+        setSkillProficiency: (skill, level) =>
+          applyToActive((record) => {
+            if (level === null) {
+              return {
+                skillProficiencies: record.skillProficiencies.filter(
+                  (p) => p.skill !== skill
+                ),
+              };
+            }
+            const existing = record.skillProficiencies.find(
+              (p) => p.skill === skill
+            );
+            if (existing) {
+              return {
+                skillProficiencies: record.skillProficiencies.map((p) =>
+                  p.skill === skill ? { ...p, proficiencyLevel: level } : p
+                ),
+              };
+            }
+            return {
+              skillProficiencies: [
+                ...record.skillProficiencies,
+                { skill, proficiencyLevel: level },
+              ],
+            };
+          }),
+        setSkillOverride: (skill, value) =>
+          applyToActive((record) => {
+            const overrides = { ...record.skillOverrides };
+            if (value === null) {
+              delete overrides[skill];
+            } else {
+              overrides[skill] = value;
+            }
+            return { skillOverrides: overrides };
+          }),
+        setTraitChoice: (groupKey, choiceLabel) =>
+          applyToActive((record) => ({
+            traitChoices: { ...record.traitChoices, [groupKey]: choiceLabel },
+          })),
+        setDruidName: (name) => applyToActive({ name }),
+
+        createDruid: (name) => {
+          const record = recordFromDefaults(name);
+          set((state) => ({
+            ...record,
+            druids: { ...state.druids, [record.id]: record },
+            druidOrder: [...state.druidOrder, record.id],
+            activeDruidId: record.id,
+          }));
+          return record.id;
+        },
+
+        deleteDruid: (id) => {
+          const state = get();
+          if (state.druidOrder.length <= 1) {
+            return;
           }
-          return { skillOverrides: overrides };
-        }),
-      setTraitChoice: (groupKey, choiceLabel) =>
-        set((state) => ({
-          traitChoices: { ...state.traitChoices, [groupKey]: choiceLabel },
-        })),
-    }),
+          const druids = { ...state.druids };
+          delete druids[id];
+          const druidOrder = state.druidOrder.filter((d) => d !== id);
+
+          if (state.activeDruidId !== id) {
+            set({ druids, druidOrder });
+            return;
+          }
+
+          const nextActiveId = druidOrder[0];
+          const nextRecord = druids[nextActiveId];
+          set({
+            ...nextRecord,
+            druids,
+            druidOrder,
+            activeDruidId: nextActiveId,
+          });
+        },
+
+        setActiveDruid: (id) => {
+          const record = get().druids[id];
+          if (!record) {
+            return;
+          }
+          set({ ...record, activeDruidId: id });
+        },
+      };
+    },
     {
       name: 'druid-storage',
       storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
+      migrate: migrateDruidStorage,
     }
   )
 );

--- a/src/utils/calculations/__tests__/wildShape.test.ts
+++ b/src/utils/calculations/__tests__/wildShape.test.ts
@@ -711,6 +711,7 @@ function createMockDruid(options: {
   otherClassLevels?: Record<string, number>;
 }): Druid {
   return {
+    id: 'test-druid',
     name: 'Test Druid',
     edition: options.edition || '2024',
     size: 'Medium',

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,6 @@
+export function generateId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary
- Druids are now named and switchable: a dropdown near the top of the app lists all saved druids by name.
- "+ New Druid" prompts for a name, creates a druid with default stats (2024 edition, level 2, no circle), and switches to it on the Character tab.
- "Delete {name}" deletes the active druid behind a confirmation dialog; the control is hidden when only one druid remains, since the app always needs at least one.
- Existing single-druid data is auto-migrated (via a zustand `persist` migration) into the new structure as one druid named "My Druid" — no user-facing prompt, no data loss.
- Druid name is now an editable field on the Character Setup screen.

Closes #26

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run test` (249 tests, including new migration/store coverage for create, switch, rename, delete, and the last-druid-delete guard)
- [x] Manually verified in browser: fresh install, legacy-data migration, create/switch/rename/delete flows, and cross-tab consistency
